### PR TITLE
Fix Preset Button Styling for UI Consistency

### DIFF
--- a/index.html
+++ b/index.html
@@ -1369,8 +1369,8 @@
               <span>${typeInfo}</span>
             </div>
             <div class="preset-actions" onclick="event.stopPropagation()">
-              <button class="btn btn-outline" style="height: 35px; padding: 0 15px; font-size: 14px;" onclick="loadPreset(${preset.id})">Load</button>
-              <button class="btn btn-danger" style="height: 35px; padding: 0 15px; font-size: 14px;" onclick="deletePreset(${preset.id})">Delete</button>
+              <button class="btn btn-outline" onclick="loadPreset(${preset.id})">Load</button>
+              <button class="btn btn-outline" style="color: #EF4444; border-color: #EF4444;" onclick="deletePreset(${preset.id})">Delete</button>
             </div>
           </div>
         `;


### PR DESCRIPTION
## Summary
Updated Load and Delete buttons in preset cards to match the consistent styling used throughout the application.

## Changes
✅ Removed oversized custom styling from preset card buttons
✅ Load button now uses standard `btn-outline` class
✅ Delete button uses `btn-outline` with red accent color for destructive action
✅ Buttons now match Export/Import buttons and all other UI elements

## Before
- Buttons were 35px height with custom padding and font size
- Inconsistent with rest of the UI

## After
- Buttons use standard sizing matching Export Presets, Import Presets
- Visual consistency across entire application
- Delete button maintains red color to indicate destructive action

🤖 Generated with Claude Code