### PR TITLE
Update download links to version 1.0.6 across all platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ Professional folder and file management application for Mac and Windows.
 
 ### **For Mac Users**
 
-**Apple Silicon (M1/M2/M3/M4):**
-➡️ **[Download for Mac (Apple Silicon)](https://github.com/IntoTheWild-Dev/FolderPilot/releases/download/v1.0.5/FolderPilot-1.0.5-arm64.dmg)**
+`**Apple Silicon (M1/M2/M3/M4):**
+➡️ **[Download for Mac (Apple Silicon)](https://github.com/IntoTheWild-Dev/FolderPilot/releases/download/v1.0.6/FolderPilot-1.0.6-arm64.dmg)**
 
 **Intel Macs:**
-➡️ **[Download for Mac (Intel)](https://github.com/IntoTheWild-Dev/FolderPilot/releases/download/v1.0.5/FolderPilot-1.0.5.dmg)**
+➡️ **[Download for Mac (Intel)](https://github.com/IntoTheWild-Dev/FolderPilot/releases/download/v1.0.6/FolderPilot-1.0.6.dmg)**`
 
 ### **For Windows Users**
 
-➡️ **[Download for Windows](https://github.com/IntoTheWild-Dev/FolderPilot/releases/download/v1.0.5/FolderPilot-Setup-1.0.5.exe)**
+➡️ **[Download for Windows](https://github.com/IntoTheWild-Dev/FolderPilot/releases/download/v1.0.6/FolderPilot-Setup-1.0.6.exe)**
 
 ---
 


### PR DESCRIPTION
- Change Mac Apple Silicon download link from v1.0.5 to v1.0.6
- Change Mac Intel download link from v1.0.5 to v1.0.6
- Change Windows download link from v1.0.5 to v1.0.6